### PR TITLE
Optional slack notifications

### DIFF
--- a/rezervo/notify/notify.py
+++ b/rezervo/notify/notify.py
@@ -86,7 +86,7 @@ def notify_booking(
             notify_booking_web_push(subscription, booked_class)
             notified = True
     slack_config = notifications_config.slack
-    if slack_config is not None:
+    if slack_config is not None and slack_config.user_id is not None:
         scheduled_reminder_id = None
         if notifications_config.reminder_hours_before is not None:
             scheduled_reminder_id = schedule_class_reminder(

--- a/rezervo/schemas/config/admin.py
+++ b/rezervo/schemas/config/admin.py
@@ -4,7 +4,7 @@ from rezervo.schemas.base import OrmBase
 
 
 class Slack(OrmBase):
-    user_id: str
+    user_id: Optional[str] = None
 
 
 class Notifications(OrmBase):

--- a/rezervo/schemas/config/user.py
+++ b/rezervo/schemas/config/user.py
@@ -9,6 +9,7 @@ from rezervo.schemas.base import OrmBase
 
 class Notifications(OrmBase):
     reminder_hours_before: Optional[float] = None
+    slack_notifications: Optional[bool] = None
 
 
 class ClassTime(OrmBase):


### PR DESCRIPTION
This PR enables booking without having a slack_id configured, eg. the user does not have Slack notifications configured.

In addition, I pass whether or not they have a Slack config to the frontend so that we can hide the "hours before" settings if they are not part of the inner Slack circle. 