### PR TITLE
fix(sessions): increase number of weeks to include 3T events booked one month in advance

### DIFF
--- a/rezervo/consts.py
+++ b/rezervo/consts.py
@@ -1,7 +1,7 @@
 WEEKDAYS = ["Mandag", "Tirsdag", "Onsdag", "Torsdag", "Fredag", "Lørdag", "Søndag"]
 
 # The number of whole weeks to fetch in addition to the rest of the current week when looking at planned sessions
-PLANNED_SESSIONS_NEXT_WHOLE_WEEKS = 2
+PLANNED_SESSIONS_NEXT_WHOLE_WEEKS = 4
 
 SLACK_ACTION_ADD_BOOKING_TO_CALENDAR = "add_booking_to_calendar"
 SLACK_ACTION_CANCEL_BOOKING = "cancel_booking"


### PR DESCRIPTION
This previously threw an error when pulling sessions, since we did not fetch the details about all the classes in the schedule. (we did not expect classes to booked be more than 2 weeks ahead)