### PR TITLE
Fetch Past Sessions for BRPSystems

### DIFF
--- a/rezervo/providers/brpsystems/booking.py
+++ b/rezervo/providers/brpsystems/booking.py
@@ -32,7 +32,7 @@ MAX_SEARCH_ATTEMPTS = 6
 def booking_url(
     subdomain: BrpSubdomain, auth_result: BrpAuthResult, start_time_point: datetime
 ) -> str:
-    return f"https://{subdomain.value}.brpsystems.com/brponline/api/ver3/customers/{auth_result['username']}/bookings/groupactivities?startTimePoint={start_time_point.strftime('%Y-%m-%dT%H:%M:%S')}.000Z"
+    return f"https://{subdomain.value}.brpsystems.com/brponline/api/ver3/customers/{auth_result['username']}/bookings/groupactivities?startTimePoint={start_time_point.astimezone(pytz.UTC).strftime('%Y-%m-%dT%H:%M:%S')}.000Z"
 
 
 def find_brp_class_by_id(

--- a/rezervo/providers/brpsystems/booking.py
+++ b/rezervo/providers/brpsystems/booking.py
@@ -29,8 +29,10 @@ from rezervo.utils.str_utils import format_name_list_to_natural
 MAX_SEARCH_ATTEMPTS = 6
 
 
-def booking_url(subdomain: BrpSubdomain, auth_result: BrpAuthResult) -> str:
-    return f"https://{subdomain.value}.brpsystems.com/brponline/api/ver3/customers/{auth_result['username']}/bookings/groupactivities"
+def booking_url(
+    subdomain: BrpSubdomain, auth_result: BrpAuthResult, start_time_point: datetime
+) -> str:
+    return f"https://{subdomain.value}.brpsystems.com/brponline/api/ver3/customers/{auth_result['username']}/bookings/groupactivities?startTimePoint={start_time_point.strftime('%Y-%m-%dT%H:%M:%S')}.000Z"
 
 
 def find_brp_class_by_id(
@@ -151,7 +153,7 @@ def book_brp_class(
     subdomain: BrpSubdomain, auth_result: BrpAuthResult, class_id: int
 ) -> bool:
     response = requests.post(
-        booking_url(subdomain, auth_result),
+        booking_url(subdomain, auth_result, datetime.now()),
         json={"groupActivity": class_id, "allowWaitingList": True},
         headers={
             "Content-Type": "application/json",
@@ -249,7 +251,7 @@ def try_cancel_brp_booking(
         return auth_result
     try:
         res = requests.get(
-            booking_url(subdomain, auth_result),
+            booking_url(subdomain, auth_result, datetime.now()),
             headers={
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {auth_result['access_token']}",

--- a/rezervo/providers/brpsystems/schema.py
+++ b/rezervo/providers/brpsystems/schema.py
@@ -128,6 +128,7 @@ class BookingData(BaseModel):
     waitingListBooking: Optional[WaitingListBooking] = None
     groupActivityBooking: Optional[GroupActivityBooking] = None
     additionToEventBooking: Optional[object] = None
+    checkedIn: Optional[str] = None
 
 
 class Country(BaseModel):
@@ -195,7 +196,12 @@ class UserDetails(BaseModel):
     lastPasswordChangedTime: str
 
 
-def session_state_from_brp(booking_type: BookingType) -> SessionState:
+def session_state_from_brp(
+    booking_type: BookingType, checked_in: Optional[str]
+) -> SessionState:
+    if checked_in is not None:
+        return SessionState.CONFIRMED
+
     match booking_type:
         case BookingType.GROUP_ACTIVITY:
             return SessionState.BOOKED

--- a/rezervo/providers/brpsystems/sessions.py
+++ b/rezervo/providers/brpsystems/sessions.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List, Optional
 from uuid import UUID
 
@@ -40,6 +40,7 @@ def fetch_brp_sessions(
         subdomain,
         business_unit,
         days=total_days_for_next_whole_weeks(PLANNED_SESSIONS_NEXT_WHOLE_WEEKS),
+        from_date=datetime.now() - timedelta(weeks=1),
     )
     with SessionLocal() as db:
         db_brp_users_query = db.query(models.IntegrationUser).filter(
@@ -62,7 +63,11 @@ def fetch_brp_sessions(
                 continue
             try:
                 res = requests.get(
-                    booking_url(subdomain, auth_result),
+                    booking_url(
+                        subdomain,
+                        auth_result,
+                        start_time_point=datetime.now() - timedelta(weeks=1),
+                    ),
                     headers={
                         "Authorization": f"Bearer {auth_result['access_token']}",
                     },
@@ -90,7 +95,7 @@ def fetch_brp_sessions(
                         integration=SUBDOMAIN_TO_INTEGRATION_IDENTIFIER[subdomain],
                         class_id=s.groupActivity.id,
                         user_id=brp_user.user_id,
-                        status=session_state_from_brp(s.type),
+                        status=session_state_from_brp(s.type, s.checkedIn),
                         class_data=rezervo_class_from_brp_class(subdomain, brp_class),
                     )
                 )


### PR DESCRIPTION
This PR extends the BRP session functionality so that it fetches the sessions that the user has partaken in. This makes it possible to look back at previous BRP bookings.

I observed that the bookings endpoint does not have any pagination, so we can fetch all historic bookings for each user if desirable. For now, I put it fetching bookings up to one week in the past, so that future bookings will be remembered.