### PR TITLE
feat: ical feed alarms if notifications on

### DIFF
--- a/rezervo/api/cal.py
+++ b/rezervo/api/cal.py
@@ -55,7 +55,8 @@ def get_calendar(token: str, include_past: bool = True, db: Session = Depends(ge
     for s in sessions_query.all():
         if s.class_data is None:
             continue
-        event = ical_event_from_session(UserSession.from_orm(s))
+        user_config = crud.get_user_config(db, db_user).config
+        event = ical_event_from_session(UserSession.from_orm(s), user_config)
         if event is not None:
             ical.add_component(event)
     return Response(content=ical.to_ical(), media_type="text/calendar")


### PR DESCRIPTION
Adds alarms to the iCal feed events based on the notification settings.
The class calendar events will give notifications in the calendar client
when the notification setting says they should (at the same time as
Slack).
