### PR TITLE
Add Additional Activity Information 

### DIFF
--- a/rezervo/providers/brpsystems/provider.py
+++ b/rezervo/providers/brpsystems/provider.py
@@ -320,6 +320,7 @@ class BrpProvider(Provider[BrpAuthResult, BrpLocationIdentifier]):
                 description=brp_class.activity_details.description
                 if isinstance(brp_class, DetailedBrpClass)
                 else "",
+                additional_information=brp_class.externalMessage,
                 color=category.color,
                 image=brp_class.activity_details.image_url
                 if isinstance(brp_class, DetailedBrpClass)

--- a/rezervo/providers/brpsystems/provider.py
+++ b/rezervo/providers/brpsystems/provider.py
@@ -286,7 +286,9 @@ class BrpProvider(Provider[BrpAuthResult, BrpLocationIdentifier]):
         subdomain: BrpSubdomain,
         brp_class: BrpClass | DetailedBrpClass,
     ) -> RezervoClass:
-        category = determine_activity_category(brp_class.name)
+        category = determine_activity_category(
+            brp_class.name, brp_class.externalMessage is not None
+        )
         return RezervoClass(
             id=brp_class.id,  # TODO: check if unique across all subdomains
             start_time=datetime.datetime.fromisoformat(

--- a/rezervo/schemas/schedule.py
+++ b/rezervo/schemas/schedule.py
@@ -32,6 +32,7 @@ class RezervoActivity(CamelModel):
     name: str
     category: str
     description: str
+    additional_information: Optional[str] = None
     color: str
     image: Optional[str] = None
 

--- a/rezervo/utils/category_utils.py
+++ b/rezervo/utils/category_utils.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic.main import BaseModel
 
 
@@ -110,7 +112,11 @@ ACTIVITY_CATEGORIES = [
 ]
 
 
-def determine_activity_category(activity_name: str) -> RezervoCategory:
+def determine_activity_category(
+    activity_name: str, has_additional_information: Optional[bool] = False
+) -> RezervoCategory:
+    if has_additional_information:
+        return OTHER_ACTIVITY_CATEGORY
     for category in ACTIVITY_CATEGORIES:
         for keyword in category.keywords:
             if keyword in activity_name.lower():


### PR DESCRIPTION
This PR adds a field for additional information on activities. This is useful for BRP gyms, since they frequently use the externalMessage to indicate special events. 

To better help visualize this in the front end, I have changed the category for events with this message to the "other" event type. (since the presence of additional information usually equates to "something cool is happening, I better not miss this")

Related to https://github.com/mathiazom/rezervo-web/pull/105