### PR TITLE
feat(schedule): append cancel text to RezervoClass if present

### DIFF
--- a/rezervo/providers/ibooking/provider.py
+++ b/rezervo/providers/ibooking/provider.py
@@ -202,6 +202,7 @@ class IBookingProvider(Provider[IBookingAuthResult, IBookingLocationIdentifier])
             ),
             is_bookable=ibooking_class.bookable,
             is_cancelled=ibooking_class.cancelText is not None,
+            cancel_text=ibooking_class.cancelText,
             total_slots=ibooking_class.capacity,
             available_slots=ibooking_class.available,
             waiting_list_count=ibooking_class.waitlist.count,

--- a/rezervo/schemas/schedule.py
+++ b/rezervo/schemas/schedule.py
@@ -53,6 +53,7 @@ class SessionRezervoClass(BaseRezervoClass):
 class RezervoClass(BaseRezervoClass):
     is_bookable: bool
     is_cancelled: bool
+    cancel_text: Optional[str]
     total_slots: Optional[int]
     available_slots: Optional[int]
     waiting_list_count: Optional[int]


### PR DESCRIPTION
This PR adds the cancel text to classes if present. Currently, only iBooking uses cancel texts, while BRP just does not give any reason (afaik)