### PR TITLE
Add User Endpoint

### DIFF
--- a/rezervo/api/api.py
+++ b/rezervo/api/api.py
@@ -13,6 +13,7 @@ from rezervo.api import (
     schedules,
     sessions,
     slack,
+    user,
 )
 from rezervo.api.notifications import push
 from rezervo.http_client import HttpClient
@@ -31,3 +32,4 @@ api.include_router(sessions.router, tags=["sessions"])
 api.include_router(cal.router, tags=["calendar"])
 api.include_router(push.router, tags=["notifications"])
 api.include_router(slack.router, tags=["slack"])
+api.include_router(user.router, tags=["user"])

--- a/rezervo/api/user.py
+++ b/rezervo/api/user.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from starlette import status
+
+from rezervo.api.common import get_db, token_auth_scheme
+from rezervo.auth import auth0
+from rezervo.database import crud
+from rezervo.settings import Settings, get_settings
+
+router = APIRouter()
+
+
+class User(BaseModel):
+    name: str
+
+
+@router.put("/user", response_model=User)
+def upsert_user(
+    user: User,
+    token=Depends(token_auth_scheme),
+    db: Session = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+):
+    db_user = crud.user_from_token(db, settings, token)
+
+    if db_user is None:
+        jwt_sub = auth0.sub_from_jwt(
+            token,
+            settings.JWT_DOMAIN,
+            settings.JWT_ALGORITHMS,
+            settings.JWT_AUDIENCE,
+            settings.JWT_ISSUER,
+        )
+        if not isinstance(jwt_sub, str):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+        crud.create_user(db, user.name, jwt_sub)
+    else:
+        db_user.name = user.name
+        db.commit()
+
+    return user

--- a/rezervo/api/user.py
+++ b/rezervo/api/user.py
@@ -12,7 +12,7 @@ from rezervo.settings import Settings, get_settings
 router = APIRouter()
 
 
-@router.put("/user")
+@router.put("/user", status_code=status.HTTP_204_NO_CONTENT)
 def upsert_user(
     token=Depends(token_auth_scheme),
     db: Session = Depends(get_db),

--- a/rezervo/api/user.py
+++ b/rezervo/api/user.py
@@ -1,42 +1,39 @@
+from auth0.management import Auth0
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from starlette import status
 
 from rezervo.api.common import get_db, token_auth_scheme
 from rezervo.auth import auth0
+from rezervo.auth.auth0 import get_auth0_management_client
 from rezervo.database import crud
 from rezervo.settings import Settings, get_settings
 
 router = APIRouter()
 
 
-class User(BaseModel):
-    name: str
-
-
-@router.put("/user", response_model=User)
+@router.put("/user")
 def upsert_user(
-    user: User,
     token=Depends(token_auth_scheme),
     db: Session = Depends(get_db),
     settings: Settings = Depends(get_settings),
+    auth0_mgmt_client: Auth0 = Depends(get_auth0_management_client),
 ):
+    jwt_sub = auth0.sub_from_jwt(
+        token,
+        settings.JWT_DOMAIN,
+        settings.JWT_ALGORITHMS,
+        settings.JWT_AUDIENCE,
+        settings.JWT_ISSUER,
+    )
+    if not isinstance(jwt_sub, str):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+
+    name = auth0_mgmt_client.users.get(jwt_sub)["name"]  # type: ignore
+
     db_user = crud.user_from_token(db, settings, token)
-
     if db_user is None:
-        jwt_sub = auth0.sub_from_jwt(
-            token,
-            settings.JWT_DOMAIN,
-            settings.JWT_ALGORITHMS,
-            settings.JWT_AUDIENCE,
-            settings.JWT_ISSUER,
-        )
-        if not isinstance(jwt_sub, str):
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
-        crud.create_user(db, user.name, jwt_sub)
+        crud.create_user(db, name, jwt_sub)
     else:
-        db_user.name = user.name
+        db_user.name = name
         db.commit()
-
-    return user


### PR DESCRIPTION
This PR adds an endpoint to make sure that the stored user is up to date. 

If there is no user, a fresh user is created with the `jwt_sub` and `name` from auth0. This is useful when creating new users, as there is no longer any need to use the shell to do so. All you have to do is to create a new Auth0 user, which you have to do anyways.

If there is already a user, our stored `name` is updated. This way, the name stored in our database is always up to date with the one in Auth0. (which for instance makes it simpler to change, as it is just the GUI setting in the tenant)