### PR TITLE
Adjust Category Colors

### DIFF
--- a/rezervo/utils/category_utils.py
+++ b/rezervo/utils/category_utils.py
@@ -14,7 +14,7 @@ class RezervoCategory(RezervoBaseCategory):
 
 OTHER_ACTIVITY_CATEGORY = RezervoCategory(
     name="Annet",
-    color="#FFFF66",
+    color="#FFEE00",
     keywords=["happening", "event"],
 )
 
@@ -22,7 +22,7 @@ ACTIVITY_CATEGORIES = [
     OTHER_ACTIVITY_CATEGORY,
     RezervoCategory(
         name="Tilleggstjenester",
-        color="#f4eded",
+        color="#CFCFCF",
         keywords=["tilleggstjenester", "barnepass", "kroppsanalyse"],
     ),
     RezervoCategory(


### PR DESCRIPTION
These changes are needed by https://github.com/mathiazom/rezervo-web/pull/109 to give the checkboxes better contrast in light mode. I also feel like the new colors are more fitting:

- The "Annet" category represents special classes, and thus a bit more of a golden (royal) color is fitting, while still being quite eye-catching. The current color is also a bit too washy.
- The "Tilleggstjenester" was a bit too close to white in light mode IMO, now it is a bit more visible and consistent with the rest of the colors. (while still having a color denoting that these are not that interesting)
 
### Light Mode

#### Before
<img width="1512" alt="Screenshot 2024-02-12 at 13 13 11" src="https://github.com/mathiazom/rezervo-web/assets/26925695/35efde79-2a34-46d6-b8cb-4c82d230c221">

#### After
<img width="1512" alt="Screenshot 2024-02-12 at 13 13 07" src="https://github.com/mathiazom/rezervo-web/assets/26925695/c30be76c-111d-4447-92f8-10b58afd9f44">

### Dark Mode

#### Before
<img width="1512" alt="Screenshot 2024-02-12 at 13 13 26" src="https://github.com/mathiazom/rezervo-web/assets/26925695/deb9c353-b998-4c34-bdaa-cafa0b2028d4">

#### After
<img width="1512" alt="Screenshot 2024-02-12 at 13 13 21" src="https://github.com/mathiazom/rezervo-web/assets/26925695/ee64d044-f78e-4e36-b792-a9b478cc802a">