### PR TITLE
Optimistically add/remove session after successful booking/cancellation

### DIFF
--- a/rezervo/api/booking.py
+++ b/rezervo/api/booking.py
@@ -15,7 +15,7 @@ from rezervo.database import crud
 from rezervo.errors import AuthenticationError, BookingError
 from rezervo.schemas.config.config import ConfigValue
 from rezervo.schemas.config.user import ChainIdentifier, ChainUser
-from rezervo.sessions import pull_sessions
+from rezervo.sessions import add_session, remove_session
 from rezervo.settings import Settings, get_settings
 from rezervo.utils.logging_utils import err
 
@@ -78,8 +78,7 @@ async def book_class_api(
             )
         case BookingError():
             return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
-    # Pulling in foreground to have sessions up-to-date once the response is sent
-    await pull_sessions(chain_identifier, chain_user.user_id)
+    await add_session(chain_identifier, chain_user.user_id, _class)
 
 
 class BookingCancellationPayload(BaseModel):
@@ -124,5 +123,4 @@ async def cancel_booking_api(
             )
         case BookingError():
             return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
-    # Pulling in foreground to have sessions up-to-date once the response is sent
-    await pull_sessions(chain_identifier, chain_user.user_id)
+    await remove_session(chain_identifier, chain_user.user_id, _class.id)

--- a/rezervo/api/booking.py
+++ b/rezervo/api/booking.py
@@ -15,7 +15,7 @@ from rezervo.database import crud
 from rezervo.errors import AuthenticationError, BookingError
 from rezervo.schemas.config.config import ConfigValue
 from rezervo.schemas.config.user import ChainIdentifier, ChainUser
-from rezervo.sessions import add_session, remove_session
+from rezervo.sessions import remove_session, upsert_booked_session
 from rezervo.settings import Settings, get_settings
 from rezervo.utils.logging_utils import err
 
@@ -78,7 +78,7 @@ async def book_class_api(
             )
         case BookingError():
             return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
-    await add_session(chain_identifier, chain_user.user_id, _class)
+    await upsert_booked_session(chain_identifier, chain_user.user_id, _class)
 
 
 class BookingCancellationPayload(BaseModel):

--- a/rezervo/sessions.py
+++ b/rezervo/sessions.py
@@ -2,10 +2,17 @@ import asyncio
 from typing import Optional
 from uuid import UUID
 
+from rezervo import models
 from rezervo.chains.active import ACTIVE_CHAIN_IDENTIFIERS, get_chain
 from rezervo.database import crud
 from rezervo.database.database import SessionLocal
+from rezervo.models import SessionState
 from rezervo.schemas.config.user import ChainIdentifier
+from rezervo.schemas.schedule import (
+    RezervoClass,
+    UserSession,
+    session_model_from_user_session,
+)
 from rezervo.utils.logging_utils import err
 
 
@@ -46,3 +53,35 @@ async def pull_sessions(
     await asyncio.gather(
         *[pull_chain_sessions(i, user_id) for i in ACTIVE_CHAIN_IDENTIFIERS]
     )
+
+
+async def add_session(
+    chain_identifier: ChainIdentifier, user_id: UUID, _class: RezervoClass
+):
+    with SessionLocal() as db:
+        db.add(
+            session_model_from_user_session(
+                UserSession(
+                    chain=chain_identifier,
+                    class_id=_class.id,
+                    user_id=user_id,
+                    status=(
+                        SessionState.BOOKED
+                        if _class.available_slots > 0
+                        else SessionState.WAITLIST
+                    ),
+                    class_data=_class,
+                )
+            )
+        )
+        db.commit()
+
+
+async def remove_session(
+    chain_identifier: ChainIdentifier, user_id: UUID, class_id: str
+):
+    with SessionLocal() as db:
+        db.query(models.Session).filter_by(
+            chain=chain_identifier, user_id=user_id, class_id=class_id
+        ).delete()
+        db.commit()


### PR DESCRIPTION
Currently, manual booking and cancellation is suuuuuperslow due to the fact that we wait for the session pulling. With this change, we optimistically add/remove a session once the book/cancel request is successful.

Here is a quick side-by-side speed 🐎 comparison. 

## 🐌 Prod 🐌 | 🚤  This PR 🚤 

https://github.com/mathiazom/rezervo/assets/26925695/ba86ae5a-04b6-4fa4-8d9d-0dbfea5b1c26

As you can tell, the updated version can book _and_ unbook way before the old version is even done booking. 🚤 💯 