### PR TITLE
Add Endpoints for Chain Agnostic Agenda and Settings

### DIFF
--- a/rezervo/api/booking.py
+++ b/rezervo/api/booking.py
@@ -80,7 +80,7 @@ async def book_class_api(
         case BookingError():
             return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
     # optimistically update session data, but start proper sync in background
-    await upsert_booked_session(chain_identifier, chain_user.user_id, _class)
+    upsert_booked_session(chain_identifier, chain_user.user_id, _class)
     background_tasks.add_task(pull_sessions, chain_identifier, chain_user.user_id)
 
 

--- a/rezervo/api/chain_config.py
+++ b/rezervo/api/chain_config.py
@@ -102,13 +102,13 @@ async def put_chain_config(
     if updated_config is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
+    # optimistically update session data, but start proper sync in background
     await update_planned_sessions(
         chain_identifier,
         db_user.id,  # type: ignore
         previous_config,
         updated_config,
     )
-    # optimistically update session data, but start proper sync in background
     background_tasks.add_task(pull_sessions, chain_identifier, db_user.id)  # type: ignore
     # TODO: debounce refresh to better handle burst updates
     background_tasks.add_task(refresh_cron, db_user.id, [chain_identifier])

--- a/rezervo/api/chain_config.py
+++ b/rezervo/api/chain_config.py
@@ -105,8 +105,8 @@ async def put_chain_config(
     await update_planned_sessions(
         chain_identifier,
         db_user.id,  # type: ignore
-        previous_config.recurring_bookings if previous_config else [],
-        updated_config.recurring_bookings,
+        previous_config,
+        updated_config,
     )
     # optimistically update session data, but start proper sync in background
     background_tasks.add_task(pull_sessions, chain_identifier, db_user.id)  # type: ignore

--- a/rezervo/api/chain_config.py
+++ b/rezervo/api/chain_config.py
@@ -93,7 +93,7 @@ async def put_chain_config(
     db_user = crud.user_from_token(db, settings, token)
     if db_user is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
-    previous_config = crud.get_chain_config(db, chain_identifier, db_user.id)  # type: ignore
+    previous_config = crud.get_chain_config(db, chain_identifier, db_user.id)
     updated_config = crud.update_chain_config(
         db,
         db_user.id,
@@ -105,11 +105,11 @@ async def put_chain_config(
     # optimistically update session data, but start proper sync in background
     await update_planned_sessions(
         chain_identifier,
-        db_user.id,  # type: ignore
+        db_user.id,
         previous_config,
         updated_config,
     )
-    background_tasks.add_task(pull_sessions, chain_identifier, db_user.id)  # type: ignore
+    background_tasks.add_task(pull_sessions, chain_identifier, db_user.id)
     # TODO: debounce refresh to better handle burst updates
     background_tasks.add_task(refresh_cron, db_user.id, [chain_identifier])
     return updated_config

--- a/rezervo/api/chain_config.py
+++ b/rezervo/api/chain_config.py
@@ -16,6 +16,10 @@ from rezervo.schemas.config.user import (
     ChainUserProfile,
     UserNameWithIsSelf,
 )
+from rezervo.sessions import (
+    pull_sessions,
+    update_planned_sessions,
+)
 from rezervo.settings import Settings, get_settings
 from rezervo.utils.config_utils import class_config_recurrent_id
 
@@ -78,7 +82,7 @@ def get_chain_config(
 
 
 @router.put("/{chain_identifier}/config", response_model=BaseChainConfig)
-def put_chain_config(
+async def put_chain_config(
     chain_identifier: ChainIdentifier,
     chain_config: BaseChainConfig,
     background_tasks: BackgroundTasks,
@@ -89,6 +93,7 @@ def put_chain_config(
     db_user = crud.user_from_token(db, settings, token)
     if db_user is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    previous_config = crud.get_chain_config(db, chain_identifier, db_user.id)  # type: ignore
     updated_config = crud.update_chain_config(
         db,
         db_user.id,
@@ -96,6 +101,15 @@ def put_chain_config(
     )
     if updated_config is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    await update_planned_sessions(
+        chain_identifier,
+        db_user.id,  # type: ignore
+        previous_config.recurring_bookings if previous_config else [],
+        updated_config.recurring_bookings,
+    )
+    # optimistically update session data, but start proper sync in background
+    background_tasks.add_task(pull_sessions, chain_identifier, db_user.id)  # type: ignore
     # TODO: debounce refresh to better handle burst updates
     background_tasks.add_task(refresh_cron, db_user.id, [chain_identifier])
     return updated_config

--- a/rezervo/api/sessions.py
+++ b/rezervo/api/sessions.py
@@ -14,7 +14,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/{chain_identifier}/sessions",
+    "/{chain_identifier}/sessions-index",
     response_model=dict[str, list[UserNameSessionStatus]],
 )
 def get_sessions_index(

--- a/rezervo/api/user.py
+++ b/rezervo/api/user.py
@@ -9,7 +9,7 @@ from rezervo.auth import auth0
 from rezervo.auth.auth0 import get_auth0_management_client
 from rezervo.database import crud
 from rezervo.schemas.config.user import ChainConfig, ChainIdentifier
-from rezervo.schemas.schedule import UserAgendaClass
+from rezervo.schemas.schedule import BaseUserSession
 from rezervo.settings import Settings, get_settings
 
 router = APIRouter()
@@ -43,10 +43,10 @@ def upsert_user(
 
 
 @router.get(
-    "/user/agenda",
-    response_model=list[UserAgendaClass],
+    "/user/sessions",
+    response_model=list[BaseUserSession],
 )
-def get_user_agenda(
+def get_user_sessions(
     token=Depends(token_auth_scheme),
     db: Session = Depends(get_db),
     settings: Settings = Depends(get_settings),
@@ -71,7 +71,7 @@ def get_user_agenda(
     )
 
     return [
-        UserAgendaClass(
+        BaseUserSession(
             chain=session.chain,  # type: ignore
             status=session.status,  # type: ignore
             class_data=session.class_data,  # type: ignore

--- a/rezervo/api/user.py
+++ b/rezervo/api/user.py
@@ -72,9 +72,9 @@ def get_user_sessions(
 
     return [
         BaseUserSession(
-            chain=session.chain,  # type: ignore
-            status=session.status,  # type: ignore
-            class_data=session.class_data,  # type: ignore
+            chain=session.chain,
+            status=session.status,
+            class_data=session.class_data,  # type: ignore[arg-type]
         )
         for session in db_sessions
     ]
@@ -94,6 +94,6 @@ def get_user_chain_configs(
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     db_chain_users = db.query(models.ChainUser).filter_by(user_id=db_user.id).all()
     return {
-        chain_user.chain: crud.get_chain_config(db, chain_user.chain, db_user.id)  # type: ignore
+        chain_user.chain: crud.get_chain_config(db, chain_user.chain, db_user.id)
         for chain_user in db_chain_users
     }

--- a/rezervo/api/user.py
+++ b/rezervo/api/user.py
@@ -8,6 +8,8 @@ from rezervo.api.common import get_db, token_auth_scheme
 from rezervo.auth import auth0
 from rezervo.auth.auth0 import get_auth0_management_client
 from rezervo.database import crud
+from rezervo.schemas.config.user import ChainConfig, ChainIdentifier
+from rezervo.schemas.schedule import UserAgendaClass
 from rezervo.settings import Settings, get_settings
 
 router = APIRouter()
@@ -38,3 +40,60 @@ def upsert_user(
     name = auth0.get_auth0_user_name(auth0_mgmt_client, jwt_sub)
     crud.create_user(db, name, jwt_sub)
     response.status_code = status.HTTP_201_CREATED
+
+
+@router.get(
+    "/user/agenda",
+    response_model=list[UserAgendaClass],
+)
+def get_user_agenda(
+    token=Depends(token_auth_scheme),
+    db: Session = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+):
+    db_user = crud.user_from_token(db, settings, token)
+    if db_user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    db_sessions = (
+        db.query(models.Session)
+        .filter(models.Session.user_id == db_user.id)
+        .filter(
+            models.Session.status.in_(
+                [
+                    models.SessionState.PLANNED,
+                    models.SessionState.BOOKED,
+                    models.SessionState.WAITLIST,
+                ]
+            )
+        )
+        .order_by(models.Session.class_data["start_time"])
+        .all()
+    )
+
+    return [
+        UserAgendaClass(
+            chain=session.chain,  # type: ignore
+            status=session.status,  # type: ignore
+            class_data=session.class_data,  # type: ignore
+        )
+        for session in db_sessions
+    ]
+
+
+@router.get(
+    "/user/chain-configs",
+    response_model=dict[ChainIdentifier, ChainConfig],
+)
+def get_user_chain_configs(
+    token=Depends(token_auth_scheme),
+    db: Session = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+):
+    db_user = crud.user_from_token(db, settings, token)
+    if db_user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    db_chain_users = db.query(models.ChainUser).filter_by(user_id=db_user.id).all()
+    return {
+        chain_user.chain: crud.get_chain_config(db, chain_user.chain, db_user.id)  # type: ignore
+        for chain_user in db_chain_users
+    }

--- a/rezervo/notify/utils.py
+++ b/rezervo/notify/utils.py
@@ -1,5 +1,8 @@
+import datetime
 from typing import Optional
 from urllib.parse import urlparse
+
+from dateutil.relativedelta import relativedelta
 
 from rezervo.http_client import HttpClient
 from rezervo.schemas.config.user import ChainIdentifier
@@ -26,8 +29,9 @@ def activity_url(
     host: Optional[str], chain_identifier: ChainIdentifier, _class: RezervoClass
 ):
     if host:
-        return (
-            f"<{host}/{chain_identifier}/?classId={_class.id}|*{_class.activity.name}*>"
-        )
+        week_offset = relativedelta(
+            _class.start_time.replace(tzinfo=None), datetime.datetime.now()
+        ).weeks
+        return f"<{host}/{chain_identifier}?weekOffset={week_offset}&classId={_class.id}|*{_class.activity.name}*>"
 
     return f"*{_class.activity.name}*"

--- a/rezervo/notify/utils.py
+++ b/rezervo/notify/utils.py
@@ -1,8 +1,5 @@
-import datetime
 from typing import Optional
 from urllib.parse import urlparse
-
-from dateutil.relativedelta import relativedelta
 
 from rezervo.http_client import HttpClient
 from rezervo.schemas.config.user import ChainIdentifier
@@ -29,9 +26,6 @@ def activity_url(
     host: Optional[str], chain_identifier: ChainIdentifier, _class: RezervoClass
 ):
     if host:
-        week_offset = relativedelta(
-            _class.start_time.replace(tzinfo=None), datetime.datetime.now()
-        ).weeks
-        return f"<{host}/{chain_identifier}?weekOffset={week_offset}&classId={_class.id}|*{_class.activity.name}*>"
+        return f"<{host}/{chain_identifier}?classId={_class.id}&startTime={_class.start_time.isoformat()}|*{_class.activity.name}*>"
 
     return f"*{_class.activity.name}*"

--- a/rezervo/providers/schedule.py
+++ b/rezervo/providers/schedule.py
@@ -21,6 +21,8 @@ def find_class_in_schedule_by_config(
         if day.day_name != weekday_str:
             continue
         for c in day.classes:
+            if c.location.id != _class_config.location_id:
+                continue
             if c.activity.id != _class_config.activity_id:
                 continue
             localized_start_time = c.start_time.astimezone(

--- a/rezervo/providers/sessions.py
+++ b/rezervo/providers/sessions.py
@@ -16,6 +16,8 @@ def get_user_planned_sessions_from_schedule(
     for d in schedule.days:
         for c in d.classes:
             for cc in chain_config.recurring_bookings:
+                if c.location.id != cc.location_id:
+                    continue
                 if d.day_name != WEEKDAYS[cc.weekday]:
                     continue
                 if c.activity.id != str(cc.activity_id):

--- a/rezervo/schemas/schedule.py
+++ b/rezervo/schemas/schedule.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from rezervo import models
 from rezervo.models import SessionState
+from rezervo.schemas.base import OrmBase
 from rezervo.schemas.camel import CamelModel
 from rezervo.schemas.config.user import ChainIdentifier
 
@@ -70,7 +71,7 @@ class RezervoSchedule(CamelModel):
     days: list[RezervoDay]
 
 
-class BaseUserSession(BaseModel):
+class BaseUserSession(OrmBase):
     chain: ChainIdentifier
     status: SessionState
     class_data: SessionRezervoClass

--- a/rezervo/schemas/schedule.py
+++ b/rezervo/schemas/schedule.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel
 
 from rezervo import models
 from rezervo.models import SessionState
-from rezervo.schemas.base import OrmBase
 from rezervo.schemas.camel import CamelModel
 from rezervo.schemas.config.user import ChainIdentifier
 
@@ -71,18 +70,15 @@ class RezervoSchedule(CamelModel):
     days: list[RezervoDay]
 
 
-class UserSession(OrmBase):
+class BaseUserSession(BaseModel):
     chain: ChainIdentifier
+    status: SessionState
+    class_data: SessionRezervoClass
+
+
+class UserSession(BaseUserSession):
     class_id: str
     user_id: UUID
-    status: SessionState
-    class_data: SessionRezervoClass
-
-
-class UserAgendaClass(BaseModel):
-    chain: ChainIdentifier
-    status: SessionState
-    class_data: SessionRezervoClass
 
 
 class UserNameSessionStatus(BaseModel):

--- a/rezervo/schemas/schedule.py
+++ b/rezervo/schemas/schedule.py
@@ -79,6 +79,12 @@ class UserSession(OrmBase):
     class_data: SessionRezervoClass
 
 
+class UserAgendaClass(BaseModel):
+    chain: ChainIdentifier
+    status: SessionState
+    class_data: SessionRezervoClass
+
+
 class UserNameSessionStatus(BaseModel):
     is_self: bool
     user_name: str

--- a/rezervo/sessions.py
+++ b/rezervo/sessions.py
@@ -130,14 +130,12 @@ async def remove_sessions(
             )
             .all()
         )
-        sessions_to_remove = [
-            session
-            for session in user_planned_sessions
-            if rezervo_class_recurrent_id(UserSession.from_orm(session).class_data)
-            in recurrent_ids_to_remove
-        ]
-        for session in sessions_to_remove:
-            db.delete(session)
+        for session in user_planned_sessions:
+            if (
+                rezervo_class_recurrent_id(UserSession.from_orm(session).class_data)
+                in recurrent_ids_to_remove
+            ):
+                db.delete(session)
         db.commit()
 
 
@@ -149,7 +147,7 @@ async def update_planned_sessions(
 ):
     previous_class_ids = (
         set()
-        if not previous_config or not previous_config.active
+        if previous_config is None or not previous_config.active
         else {
             class_config_recurrent_id(_class)
             for _class in previous_config.recurring_bookings
@@ -167,7 +165,7 @@ async def update_planned_sessions(
     removed_class_ids = previous_class_ids - updated_class_ids
     added_class_ids = updated_class_ids - previous_class_ids
 
-    if removed_class_ids:
+    if len(removed_class_ids) > 0:
         await remove_sessions(
             chain_identifier, user_id, list(removed_class_ids), SessionState.PLANNED
         )

--- a/rezervo/utils/config_utils.py
+++ b/rezervo/utils/config_utils.py
@@ -1,4 +1,7 @@
+import pytz
+
 from rezervo.schemas.config.user import Class
+from rezervo.schemas.schedule import BaseRezervoClass
 
 
 def class_config_recurrent_id(class_config: Class):
@@ -7,6 +10,18 @@ def class_config_recurrent_id(class_config: Class):
         class_config.weekday,
         class_config.start_time.hour,
         class_config.start_time.minute,
+    )
+
+
+def rezervo_class_recurrent_id(_class: BaseRezervoClass):
+    localized_start_time = _class.start_time.astimezone(
+        pytz.timezone("Europe/Oslo")
+    )  # TODO: clean this
+    return recurrent_class_id(
+        _class.activity.id,
+        localized_start_time.weekday(),
+        localized_start_time.hour,
+        localized_start_time.minute,
     )
 
 


### PR DESCRIPTION
This PR lays the foundation for the updated Agenda and Settings modals in the frontend. It both adds the neccecary endpoints, as well as some optimistic updating of the planned sessions when the config is updated. 

Related to, but not dependent on: https://github.com/mathiazom/rezervo-web/pull/115