### PR TITLE
fix(brp): include days with no classes in schedule

### DIFF
--- a/rezervo/providers/brpsystems/provider.py
+++ b/rezervo/providers/brpsystems/provider.py
@@ -2,7 +2,6 @@ import asyncio
 import datetime
 import re
 from abc import abstractmethod
-from collections import defaultdict
 from typing import Optional, Union
 
 import pydantic
@@ -242,12 +241,12 @@ class BrpProvider(Provider[BrpAuthData, BrpLocationIdentifier]):
     def _rezervo_schedule_from_brp_schedule(
         self,
         from_date: datetime.datetime,
+        days: int,
         schedule: list[BrpClass] | list[DetailedBrpClass],
     ) -> RezervoSchedule:
-        days_map: defaultdict[datetime.date, list[RezervoClass]] = defaultdict(
-            list, {from_date.date() + datetime.timedelta(days=i): [] for i in range(7)}
-        )
-
+        days_map: dict[datetime.date, list[RezervoClass]] = {
+            from_date.date() + datetime.timedelta(days=i): [] for i in range(days)
+        }
         for _class in schedule:
             class_date = datetime.datetime.fromisoformat(
                 tz_aware_iso_from_brp_date_str(_class.duration.start)
@@ -292,7 +291,7 @@ class BrpProvider(Provider[BrpAuthData, BrpLocationIdentifier]):
             ]
         ):
             schedule.extend(res)
-        return self._rezervo_schedule_from_brp_schedule(from_date, schedule)
+        return self._rezervo_schedule_from_brp_schedule(from_date, days, schedule)
 
     def rezervo_class_from_brp_class(
         self,
@@ -371,11 +370,12 @@ class BrpProvider(Provider[BrpAuthData, BrpLocationIdentifier]):
         now_date = datetime.datetime.now()
         from_date = datetime.datetime(now_date.year, now_date.month, now_date.day)
         search_result = None
+        days_per_search = SCHEDULE_SEARCH_ATTEMPT_DAYS
         while attempts < MAX_SCHEDULE_SEARCH_ATTEMPTS:
             brp_schedule = await fetch_brp_schedule(
                 subdomain,
                 business_unit,
-                days=SCHEDULE_SEARCH_ATTEMPT_DAYS,
+                days=days_per_search,
                 from_date=from_date,
             )
             if brp_schedule is None:
@@ -383,7 +383,9 @@ class BrpProvider(Provider[BrpAuthData, BrpLocationIdentifier]):
                 return BookingError.ERROR
             search_result = find_class_in_schedule_by_config(
                 _class_config,
-                self._rezervo_schedule_from_brp_schedule(from_date, brp_schedule),
+                self._rezervo_schedule_from_brp_schedule(
+                    from_date, days_per_search, brp_schedule
+                ),
             )
             if (
                 search_result is not None
@@ -401,7 +403,7 @@ class BrpProvider(Provider[BrpAuthData, BrpLocationIdentifier]):
                         brp_class = search_result
                     else:
                         break
-            from_date += datetime.timedelta(days=SCHEDULE_SEARCH_ATTEMPT_DAYS)
+            from_date += datetime.timedelta(days=days_per_search)
             attempts += 1
         if brp_class is None:
             log.warning(f"Could not find class matching criteria: {_class_config}")


### PR DESCRIPTION
If there are days in BRP with no classes, those days are not represented as RezervoDays because the default map is not initially populated with all the week's dates. The below example demonstrates how this can be an issue with for instance the 17th of May, which has no classes.

## Before
<img width="1452" alt="Screenshot 2024-04-12 at 02 08 04" src="https://github.com/mathiazom/rezervo/assets/26925695/2cbaf93a-ddde-4623-951c-9dd118948ac8">

## After
<img width="1452" alt="Screenshot 2024-04-12 at 02 07 42" src="https://github.com/mathiazom/rezervo/assets/26925695/6afbe883-1b09-4eed-a99c-63c2db710619">
