### PR TITLE
Make The "Annet" Category Stricter and Improve Contrast

### DIFF
--- a/rezervo/providers/brpsystems/provider.py
+++ b/rezervo/providers/brpsystems/provider.py
@@ -299,9 +299,7 @@ class BrpProvider(Provider[BrpAuthData, BrpLocationIdentifier]):
         subdomain: BrpSubdomain,
         brp_class: BrpClass | DetailedBrpClass,
     ) -> RezervoClass:
-        category = determine_activity_category(
-            brp_class.name, brp_class.externalMessage is not None
-        )
+        category = determine_activity_category(brp_class.name)
         return RezervoClass(
             id=str(brp_class.id),  # TODO: check if unique across all subdomains
             start_time=datetime.datetime.fromisoformat(

--- a/rezervo/utils/category_utils.py
+++ b/rezervo/utils/category_utils.py
@@ -1,4 +1,3 @@
-from typing import Optional
 
 from pydantic.main import BaseModel
 
@@ -41,6 +40,10 @@ ACTIVITY_CATEGORIES = [
             "senior",
             "baby",
             "mama",
+            "familie",
+            "kids",
+            "sprek",
+            "walk",
         ],
     ),
     RezervoCategory(
@@ -68,6 +71,7 @@ ACTIVITY_CATEGORIES = [
             "ashtanga",
             "shape",
             "flexibility",
+            "balance",
         ],
     ),
     RezervoCategory(
@@ -118,16 +122,17 @@ ACTIVITY_CATEGORIES = [
             "bootcamp",
             "olympia",
             "absolution",
+            "bodyweight",
+            "x-fit",
+            "kettlebell",
+            "skill athletic",
+            "sirkel",
         ],
     ),
 ]
 
 
-def determine_activity_category(
-    activity_name: str, has_additional_information: Optional[bool] = False
-) -> RezervoCategory:
-    if has_additional_information:
-        return OTHER_ACTIVITY_CATEGORY
+def determine_activity_category(activity_name: str) -> RezervoCategory:
     for category in ACTIVITY_CATEGORIES:
         for keyword in category.keywords:
             if keyword in activity_name.lower():

--- a/rezervo/utils/category_utils.py
+++ b/rezervo/utils/category_utils.py
@@ -1,4 +1,3 @@
-
 from pydantic.main import BaseModel
 
 
@@ -31,7 +30,7 @@ ACTIVITY_CATEGORIES = [
     ),
     RezervoCategory(
         name="Mosjon",
-        color="#00B050",
+        color="#00A050",
         keywords=[
             "mosjon",
             "godt voksen",
@@ -81,7 +80,7 @@ ACTIVITY_CATEGORIES = [
     ),
     RezervoCategory(
         name="Kondisjon",
-        color="#6AD3B4",
+        color="#C040A0",
         keywords=[
             "kondis",
             "step",


### PR DESCRIPTION
Related to https://github.com/mathiazom/rezervo-web/pull/138

> The colors are updated to make a better contrast with the ClassPopularityMeter. I think the pinkish color for cardio classes makes more sense than the green one, as it is now more similar to both spinning and dance classes in terms of color. In my head, it makes sense that similar sort of classes (in terms of cardio vs strength) has some level of similar gradients. 

Feel free to adjust colors at your leisure, but make sure to get good contrast with the PopularityMeter ✌🏻 

## Before
<img width="822" alt="Screenshot 2024-05-16 at 23 22 56" src="https://github.com/mathiazom/rezervo/assets/26925695/e8b9512e-e53a-4719-8828-0081d3a7d0ae">

## After
<img width="822" alt="Screenshot 2024-05-16 at 23 22 53" src="https://github.com/mathiazom/rezervo/assets/26925695/25d136dc-2087-4480-97dd-0aafbfdcd57f">

## Before
<img width="822" alt="Screenshot 2024-05-16 at 23 21 26" src="https://github.com/mathiazom/rezervo/assets/26925695/6e9ccfe9-1884-43b1-9426-5659ef79b114">

## After
<img width="822" alt="Screenshot 2024-05-16 at 23 20 59" src="https://github.com/mathiazom/rezervo/assets/26925695/b358c379-6881-4f73-b143-f1a71eed2cf7">
