### PR TITLE
fix(Sats): remove reference to nonexistent Sats Santa logos

### DIFF
--- a/rezervo/chains/sats.py
+++ b/rezervo/chains/sats.py
@@ -16,13 +16,13 @@ class SatsChain(Chain, SatsProvider):
     name = "Sats"
     images = ChainProfileImages(
         light=ThemeSpecificImages(
-            large_logo=f"images/chains/sats/light/logo_large{'_santa.png' if is_santa_time else ''}.png"
+            large_logo=f"images/chains/sats/light/logo_large.png"
         ),
         dark=ThemeSpecificImages(
-            large_logo=f"images/chains/sats/dark/logo_large{'_santa.png' if is_santa_time else ''}.png"
+            large_logo=f"images/chains/sats/dark/logo_large.png"
         ),
         common=ThemeAgnosticImages(
-            small_logo=f"images/chains/sats/common/logo_small{'_santa' if is_santa_time else ''}.png"
+            small_logo=f"images/chains/sats/common/logo_small.png"
         ),
     )
     branches = [


### PR DESCRIPTION
Sats does not have any Santa time images, thus resulting in a 404 when the frontend tries to fetch Sats images in December. Removed the broken references for now, but would be cool to bring back the Christmas magic for 2025 🎅🏻 