### PR TITLE
Standardize Activity Names

### DIFF
--- a/rezervo/providers/brpsystems/provider.py
+++ b/rezervo/providers/brpsystems/provider.py
@@ -1,6 +1,5 @@
 import asyncio
 import datetime
-import re
 from abc import abstractmethod
 from typing import Optional, Union
 
@@ -61,6 +60,7 @@ from rezervo.schemas.schedule import (
 from rezervo.utils.apprise_utils import aprs_ctx
 from rezervo.utils.category_utils import determine_activity_category
 from rezervo.utils.logging_utils import log
+from rezervo.utils.str_utils import standardize_activity_name
 
 
 class BrpProvider(Provider[BrpAuthData, BrpLocationIdentifier]):
@@ -342,7 +342,7 @@ class BrpProvider(Provider[BrpAuthData, BrpLocationIdentifier]):
             waiting_list_count=brp_class.slots.inWaitingList,
             activity=RezervoActivity(
                 id=str(brp_class.groupActivityProduct.id),
-                name=re.sub(r"\s\(\d+\)$", "", brp_class.groupActivityProduct.name),
+                name=standardize_activity_name(brp_class.groupActivityProduct.name),
                 category=category.name,
                 description=(
                     brp_class.activity_details.description

--- a/rezervo/providers/ibooking/provider.py
+++ b/rezervo/providers/ibooking/provider.py
@@ -60,6 +60,7 @@ from rezervo.schemas.schedule import (
 )
 from rezervo.utils.category_utils import determine_activity_category
 from rezervo.utils.logging_utils import log
+from rezervo.utils.str_utils import standardize_activity_name
 
 
 class IBookingProvider(Provider[IBookingAuthData, IBookingLocationIdentifier]):
@@ -231,7 +232,7 @@ class IBookingProvider(Provider[IBookingAuthData, IBookingLocationIdentifier]):
             waiting_list_count=ibooking_class.waitlist.count,
             activity=RezervoActivity(
                 id=str(ibooking_class.activity_id),
-                name=ibooking_class.name,
+                name=standardize_activity_name(ibooking_class.name),
                 category=determine_activity_category(ibooking_class.category.name).name,
                 description=ibooking_class.description,
                 color=ibooking_class.color,

--- a/rezervo/providers/sats/provider.py
+++ b/rezervo/providers/sats/provider.py
@@ -66,6 +66,7 @@ from rezervo.schemas.schedule import (
 )
 from rezervo.utils.category_utils import determine_activity_category
 from rezervo.utils.logging_utils import log
+from rezervo.utils.str_utils import standardize_activity_name
 
 
 class SatsProvider(Provider[SatsAuthData, SatsLocationIdentifier], ABC):
@@ -358,7 +359,7 @@ class SatsProvider(Provider[SatsAuthData, SatsLocationIdentifier], ABC):
                 id=create_activity_id(
                     sats_class.metadata.name, sats_class.metadata.clubName
                 ),  # Sats does not provide activity ids
-                name=sats_class.metadata.name,
+                name=standardize_activity_name(sats_class.metadata.name),
                 category=category.name,
                 description=sats_class.text,
                 color=category.color,

--- a/rezervo/utils/category_utils.py
+++ b/rezervo/utils/category_utils.py
@@ -71,6 +71,7 @@ ACTIVITY_CATEGORIES = [
             "shape",
             "flexibility",
             "balance",
+            "relax",
         ],
     ),
     RezervoCategory(
@@ -84,6 +85,7 @@ ACTIVITY_CATEGORIES = [
         keywords=[
             "kondis",
             "step",
+            "mølle",
             "løp",
             "puls",
             "bodyattack",
@@ -126,6 +128,11 @@ ACTIVITY_CATEGORIES = [
             "kettlebell",
             "skill athletic",
             "sirkel",
+            "powerpit",
+            "hybrid track",
+            "ukas økt",
+            "reformer",
+            "hyrox",
         ],
     ),
 ]

--- a/rezervo/utils/str_utils.py
+++ b/rezervo/utils/str_utils.py
@@ -1,6 +1,16 @@
+import re
+
+
 def format_name_list_to_natural(names: list[str]):
     return (
         names[0]
         if len(names) == 1
         else ", ".join(names[:-1]) + f" {'og ' + names[-1] if len(names) > 1 else ''}"
     )
+
+
+def standardize_activity_name(raw: str) -> str:
+    s = re.sub(r"\s\(\d+\)$", "", raw)
+    s = re.sub(r"^\s*-\s*", "", s)
+    s = re.sub(r"//+", " ", s).strip()
+    return s.title()


### PR DESCRIPTION
From September 1st, Sporty is introduction a _terrible_ text formatting for their activities, which look ok-ish in their app, but looks super whacky in rezervo-web. Therefore, I have introduced a function that standardizes activity names in terms of capitalization, removing leading "-" and replacing "//" with a space. See the before/after for reference. I decided to do the standardization for all chains, since I think it looks clean to have the same types of activity names everywhere. 🧹 

I also added some new keywords to the categorization, since there are some new workout concepts that are currently trending.

## Before
<img width="1512" height="982" alt="Screenshot 2025-08-21 at 20 23 18" src="https://github.com/user-attachments/assets/2086ecf5-e672-4ba5-9f7c-57328a2b2eac" />

## After
<img width="1512" height="982" alt="Screenshot 2025-08-21 at 20 23 25" src="https://github.com/user-attachments/assets/79b9968e-4d86-402c-be33-fa0ec0ce2ce8" />
